### PR TITLE
Removed dependency on Player from Renderer.

### DIFF
--- a/src/bomberman/Renderer.java
+++ b/src/bomberman/Renderer.java
@@ -1,7 +1,6 @@
 package bomberman;
 
 import bomberman.animations.Sprite;
-import bomberman.entity.player.Player;
 import bomberman.scenes.Sandbox;
 import bomberman.utils.ImageUtils;
 import javafx.scene.canvas.GraphicsContext;
@@ -33,13 +32,13 @@ public class Renderer {
         img = ImageUtils.loadImage("src/Resources/img/sprites.png");
     }
 
-    public static void playAnimation(Sprite sprite, Player p) {
+    public static void playAnimation(Sprite sprite) {
         double time = GameLoop.getTickDuration();
         GraphicsContext gc = Sandbox.getGraphicsContext();
         if (sprite.hasValidSpriteImages) {
-            playAnimation(sprite.spriteImages, sprite.playSpeed, p.positionX, p.positionY, sprite.width, sprite.width);
+            playAnimation(sprite.spriteImages, sprite.playSpeed, sprite.getXPosition(), sprite.getYPosition(), sprite.width, sprite.width);
         } else {
-            playAnimation(gc, time, sprite.actualSize, sprite.spriteLocationOnSheetX, sprite.spriteLocationOnSheetY, sprite.numberOfFrames, p.positionX, p.positionY, sprite.width, sprite.height, sprite.scale, sprite.resersePlay, sprite.playSpeed);
+            playAnimation(gc, time, sprite.actualSize, sprite.spriteLocationOnSheetX, sprite.spriteLocationOnSheetY, sprite.numberOfFrames, sprite.getXPosition(), sprite.getYPosition(), sprite.width, sprite.height, sprite.scale, sprite.resersePlay, sprite.playSpeed);
         }
     }
 
@@ -62,7 +61,7 @@ public class Renderer {
         int newSpriteSheetX = reversePlay ? startingPointX + index * actualSize : startingPointX;
         // newY represents the X coardinate of image in the spritesheet image to be drawn on screen
         int newSpriteSheetY = reversePlay ? startingPointY : startingPointY + index * actualSize;
-
+        System.out.println("Time, Total Frames" + time + ", " + numberOfFrames);
         System.out.println("index=" + index + " newSpriteSheetX=" + newSpriteSheetX + " newSpriteSheetY=" + newSpriteSheetY + " width=" + width + " height=" + height + " x=" + x + " y=" + y + " width=" + width * scale + " height=" + height * scale);
         //img,             sx,              sy,     w,     h,  dx, dy,        dw,             dh
         gc.drawImage(img, newSpriteSheetX, newSpriteSheetY, width, height, x, y, width * scale, height * scale);

--- a/src/bomberman/animations/Sprite.java
+++ b/src/bomberman/animations/Sprite.java
@@ -19,11 +19,13 @@ public class Sprite
 	public int scale;
 	public int actualSize;
 	public boolean resersePlay;
-        
+	private int positionX;
+	private int positionY;
+
         public Image[] spriteImages;
         public boolean hasValidSpriteImages;
-        
-	public Sprite(int actualSize, double playSpeed, int spriteLocationOnSheetX, int spriteLocationOnSheetY, int numberOfFrames, double width, double height,
+
+	public Sprite(int actualSize, double playSpeed, int positionX, int positionY, int spriteLocationOnSheetX, int spriteLocationOnSheetY, int numberOfFrames, double width, double height,
 			int scale, boolean leftToRight)
 	{
 		super();
@@ -35,23 +37,38 @@ public class Sprite
 		this.width = width;
 		this.height = height;
 		this.scale = scale;
-		this.resersePlay = leftToRight;
+		this.positionX = positionX;
+		this.positionY = positionY;
+		resersePlay = leftToRight;
 	}
-        
-        public Sprite(Image spriteSheet,Rectangle[] specifications){
-            spriteImages=new Image[specifications.length];
-            for (int i = 0; i < specifications.length; i++) {
-                Rectangle specification = specifications[i];
-                int x=(int)specification.getX();
-                int y=(int)specification.getY();
-                int w=(int)specification.getWidth();
-                int h=(int)specification.getHeight();
-                
-                //To DO Check dimensions provided are not going out of spritesheet dimensions\
-                
-                spriteImages[i]=ImageUtils.crop(spriteSheet, x, y, w, h);
-            }
-            this.numberOfFrames=specifications.length;
-            hasValidSpriteImages=true;
+
+	public int getXPosition() {
+		return positionX;
+	}
+
+	public int getYPosition() {
+		return positionY;
+	}
+
+	public void setPosition(int x, int y) {
+		positionX = x;
+		positionY = y;
+	}
+
+    public Sprite(Image spriteSheet,Rectangle[] specifications){
+        spriteImages=new Image[specifications.length];
+        for (int i = 0; i < specifications.length; i++) {
+            Rectangle specification = specifications[i];
+            int x=(int)specification.getX();
+            int y=(int)specification.getY();
+            int w=(int)specification.getWidth();
+            int h=(int)specification.getHeight();
+
+            //To DO Check dimensions provided are not going out of spritesheet dimensions\
+
+            spriteImages[i]=ImageUtils.crop(spriteSheet, x, y, w, h);
         }
+        numberOfFrames=specifications.length;
+        hasValidSpriteImages=true;
+    }
 }

--- a/src/bomberman/entity/Entity.java
+++ b/src/bomberman/entity/Entity.java
@@ -5,8 +5,6 @@
  */
 package bomberman.entity;
 
-import javafx.scene.canvas.GraphicsContext;
-
 /**
  *
  * @author Ashish

--- a/src/bomberman/entity/player/Player.java
+++ b/src/bomberman/entity/player/Player.java
@@ -2,13 +2,11 @@ package bomberman.entity.player;
 
 import bomberman.Renderer;
 import bomberman.animations.Direction;
-import bomberman.constants.GlobalConstants;
 import bomberman.animations.Sprite;
+import bomberman.constants.GlobalConstants;
 import bomberman.entity.Entity;
 import bomberman.entity.MovingEntity;
 import bomberman.entity.boundedbox.RectBoundedBox;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Player implements MovingEntity {
 
@@ -22,8 +20,6 @@ public class Player implements MovingEntity {
     Sprite moveLeft;
     Sprite moveUp;
     Sprite moveDown;
-
-    List<Sprite> spriteList = new ArrayList<Sprite>();
 
     Direction currentDirection;
 
@@ -50,10 +46,10 @@ public class Player implements MovingEntity {
         positionX = GlobalConstants.playerX;
         positionY = GlobalConstants.playerY;
 
-        Sprite moveDown = new Sprite(30, 0.1, 0, 0, 3, GlobalConstants.playerWidth, GlobalConstants.playerHeight, 2, false);
-        Sprite moveLeft = new Sprite(30, 0.1, 30, 0, 3, GlobalConstants.playerWidth, GlobalConstants.playerHeight, 2, false);
-        Sprite moveUp = new Sprite(30, 0.1, 60, 0, 3, GlobalConstants.playerWidth-1.5, GlobalConstants.playerHeight, 2, false);
-        Sprite moveRight = new Sprite(30, 0.1, 90, 0, 3, GlobalConstants.playerWidth, GlobalConstants.playerHeight, 2, false);
+        Sprite moveDown = new Sprite(30, 0.1, positionX, positionY, 3, 0, 0, GlobalConstants.playerWidth, GlobalConstants.playerHeight, 2, false);
+        Sprite moveLeft = new Sprite(30, 0.1, positionX, positionY, 30, 0, 3, GlobalConstants.playerWidth, GlobalConstants.playerHeight, 2, false);
+        Sprite moveUp = new Sprite(30, 0.1, positionX, positionY, 60, 0, 3, GlobalConstants.playerWidth-1.5, GlobalConstants.playerHeight, 2, false);
+        Sprite moveRight = new Sprite(30, 0.1, positionX, positionY, 90, 0, 3, GlobalConstants.playerWidth, GlobalConstants.playerHeight, 2, false);
 
         setMoveSprites(moveUp, moveDown, moveLeft, moveRight);
 
@@ -86,18 +82,6 @@ public class Player implements MovingEntity {
             this.moveRight = moveRight;
         }
 
-        if (!spriteList.contains(moveUp)) {
-            spriteList.add(moveUp);
-        }
-        if (!spriteList.contains(moveLeft)) {
-            spriteList.add(moveLeft);
-        }
-        if (!spriteList.contains(moveDown)) {
-            spriteList.add(moveDown);
-        }
-        if (!spriteList.contains(moveRight)) {
-            spriteList.add(moveRight);
-        }
     }
 
     public int getHealth() {
@@ -120,8 +104,9 @@ public class Player implements MovingEntity {
 
     @Override
     public void draw() {
+    	currentSprite.setPosition(positionX, positionY);
         if (currentSprite != null) {
-            Renderer.playAnimation(currentSprite, this);
+            Renderer.playAnimation(currentSprite);
         }
     }
 
@@ -159,7 +144,7 @@ public class Player implements MovingEntity {
     @Override
     public void reduceHealth(int damage) {
         if (health - damage <= 0) {
-            this.die();
+            die();
         } else {
             health -= damage;
         }


### PR DESCRIPTION
Removed dependency on Player from Renderer.

Renderer now relies on the position of the SPRITE. So, you can render any object that has a sprite attached to it through the renderer. You just need to make sure in the draw() you call currentSprite.setPosition(x,y), to make sure the sprite follows the object around.

This creates a better seperation of classes, I think, at least.
Let me know what you guys think.