### PR TITLE
added deltaTime. Refactored tickDuration

### DIFF
--- a/src/bomberman/GameLoop.java
+++ b/src/bomberman/GameLoop.java
@@ -9,24 +9,32 @@ import javafx.scene.canvas.GraphicsContext;
 
 public class GameLoop {
 
-    static double tickDuration;
+    static double currentGameTime;
+    static double oldGameTime;
+    static double deltaTime;
     final static long startNanoTime = System.nanoTime();
 
-    public static double getTickDuration() {
-        return tickDuration;
+    public static double getCurrentGameTime() {
+        return currentGameTime;
     }
 
     public static void start(GraphicsContext gc) {
         GameState.gameStatus=GlobalConstants.GameStatus.Running;
         new AnimationTimer() {
             public void handle(long currentNanoTime) {
-                tickDuration = (currentNanoTime - startNanoTime) / 1000000000.0;
+            	oldGameTime = currentGameTime;
+            	currentGameTime = (currentNanoTime - startNanoTime) / 1000000000.0;
+            	deltaTime = currentGameTime - oldGameTime;
                 gc.clearRect(0, 0, 512, 512);
                 //TODO This will have to be something like, currentScene.getEntities()
                 updateGame();
                 renderGame();
             }
         }.start();
+    }
+
+    public static double getDeltaTime() {
+    	return deltaTime * 100;
     }
 
     public static void updateGame() {

--- a/src/bomberman/Renderer.java
+++ b/src/bomberman/Renderer.java
@@ -33,7 +33,7 @@ public class Renderer {
     }
 
     public static void playAnimation(Sprite sprite) {
-        double time = GameLoop.getTickDuration();
+        double time = GameLoop.getCurrentGameTime();
         GraphicsContext gc = Sandbox.getGraphicsContext();
         if (sprite.hasValidSpriteImages) {
             playAnimation(sprite.spriteImages, sprite.playSpeed, sprite.getXPosition(), sprite.getYPosition(), sprite.width, sprite.width);
@@ -43,7 +43,7 @@ public class Renderer {
     }
 
     public static void playAnimation(Image[] imgs, double speed, int x, int y, double w, double h) {
-        double time = GameLoop.getTickDuration();
+        double time = GameLoop.getCurrentGameTime();
         GraphicsContext gc = Sandbox.getGraphicsContext();
         int numberOfFrames = imgs.length;
         int index = findCurrentFrame(time, numberOfFrames, speed);

--- a/src/bomberman/entity/player/Player.java
+++ b/src/bomberman/entity/player/Player.java
@@ -1,9 +1,10 @@
 package bomberman.entity.player;
 
+import bomberman.GameLoop;
 import bomberman.Renderer;
-import bomberman.constants.Direction;
 import bomberman.animations.PlayerAnimations;
 import bomberman.animations.Sprite;
+import bomberman.constants.Direction;
 import bomberman.constants.GlobalConstants;
 import bomberman.entity.Entity;
 import bomberman.entity.KillableEntity;
@@ -88,6 +89,10 @@ public class Player implements MovingEntity, KillableEntity {
 
     @Override
     public void move(int steps, Direction direction) {
+
+    	steps *= GameLoop.getDeltaTime();
+    	System.out.println(GameLoop.getDeltaTime());
+
         if (steps == 0) {
             setCurrentSprite(playerAnimations.getPlayerIdleSprite());
             return;
@@ -140,11 +145,11 @@ public class Player implements MovingEntity, KillableEntity {
 
     @Override
     public int getPositionX() {
-        return this.positionX;
+        return positionX;
     }
 
     @Override
     public int getPositionY() {
-        return this.positionY;
+        return positionY;
     }
 }

--- a/src/bomberman/entity/player/Player.java
+++ b/src/bomberman/entity/player/Player.java
@@ -91,7 +91,6 @@ public class Player implements MovingEntity, KillableEntity {
     public void move(int steps, Direction direction) {
 
     	steps *= GameLoop.getDeltaTime();
-    	System.out.println(GameLoop.getDeltaTime());
 
         if (steps == 0) {
             setCurrentSprite(playerAnimations.getPlayerIdleSprite());

--- a/src/bomberman/gamecontroller/InputManager.java
+++ b/src/bomberman/gamecontroller/InputManager.java
@@ -5,18 +5,18 @@
  */
 package bomberman.gamecontroller;
 
+import java.util.List;
+
 import bomberman.constants.Direction;
 import bomberman.entity.player.Player;
 import bomberman.scenes.Sandbox;
-import java.util.ArrayList;
-import java.util.List;
 import javafx.scene.input.KeyCode;
 /**
  *
  * @author Ashish
  */
 public class InputManager {
-    
+
     public static void handlePlayerMovements(){
         List keyboardInputs = EventHandler.getInputList();
         Player player = Sandbox.getPlayer();
@@ -39,11 +39,11 @@ public class InputManager {
             !keyboardInputs.contains(KeyCode.W) &&
             !keyboardInputs.contains(KeyCode.A) &&
             !keyboardInputs.contains(KeyCode.S) &&
-            !keyboardInputs.contains(KeyCode.D) 
+            !keyboardInputs.contains(KeyCode.D)
           )
         {
             player.move(0, Direction.DOWN);
         }
     }
-    
+
 }


### PR DESCRIPTION
Added deltaTime in.
This is the time in between frame updates.

I made the movement multiply by this deltaTime, which makes the movement framerate independent. (So the game doesn't appear to run in fast-forward if the user has a powerful machine).

We should do this for any values that we add every frame.

I also changed the name of 'tickDuration', as it doesn't represent the tickDuraction, but the current gametime in nanoseconds.